### PR TITLE
Support custom themes as keyword lists in set_theme/2

### DIFF
--- a/lib/tucan.ex
+++ b/lib/tucan.ex
@@ -4765,12 +4765,50 @@ defmodule Tucan do
   @doc """
   Sets the plot's theme.
 
-  Check `Tucan.Themes` for more details on theming.
+  You can pass either a built-in theme atom or a custom theme as a keyword list
+  of Vega-Lite configuration options.
+
+  ## Built-in themes
+
+  Check `Tucan.Themes` for the list of available built-in themes.
+
+      Tucan.scatter(:iris, "petal_width", "petal_length")
+      |> Tucan.set_theme(:latimes)
+
+  ## Custom themes
+
+  You can also pass a keyword list of Vega-Lite
+  [config](https://vega.github.io/vega-lite/docs/config.html) options directly:
+
+      Tucan.scatter(:iris, "petal_width", "petal_length")
+      |> Tucan.set_theme(
+        background: "#0E0E0E",
+        axis: [grid: false, label_color: "#FFF"],
+        style: [bar: [fill: "#FDDA00"]]
+      )
   """
   @doc section: :styling
-  @spec set_theme(vl :: VegaLite.t(), theme :: atom()) :: VegaLite.t()
-  def set_theme(vl, theme) do
+  @spec set_theme(vl :: VegaLite.t(), theme :: atom() | keyword()) :: VegaLite.t()
+  def set_theme(vl, theme) when is_atom(theme) do
     theme = Tucan.Themes.theme(theme)
+
+    Vl.config(vl, theme)
+  end
+
+  def set_theme(vl, theme) when is_list(theme) do
+    wrapper_keys = [:name, :theme, :doc, :source]
+
+    if Enum.any?(wrapper_keys, &Keyword.has_key?(theme, &1)) do
+      raise ArgumentError,
+            "set_theme/2 expects a keyword list of Vega-Lite config options, " <>
+              "not a theme definition. Pass the config directly, e.g. " <>
+              "set_theme(vl, background: \"#fff\", axis: [grid: false])"
+    end
+
+    if theme == [] do
+      raise ArgumentError,
+            "set_theme/2 expects a non-empty keyword list of Vega-Lite config options"
+    end
 
     Vl.config(vl, theme)
   end

--- a/test/tucan/themes_test.exs
+++ b/test/tucan/themes_test.exs
@@ -27,4 +27,30 @@ defmodule Tucan.ThemesTest do
       assert_raise ArgumentError, message, fn -> Tucan.Themes.theme(:foo) end
     end
   end
+
+  describe "set_theme/2 with keyword list" do
+    test "applies custom theme config" do
+      vl =
+        Tucan.scatter(:iris, "petal_width", "petal_length")
+        |> Tucan.set_theme(background: "#0E0E0E", axis: [grid: false])
+
+      spec = VegaLite.to_spec(vl)
+      assert spec["config"]["background"] == "#0E0E0E"
+      assert spec["config"]["axis"]["grid"] == false
+    end
+
+    test "raises on empty list" do
+      assert_raise ArgumentError, ~r/non-empty keyword list/, fn ->
+        Tucan.scatter(:iris, "petal_width", "petal_length")
+        |> Tucan.set_theme([])
+      end
+    end
+
+    test "raises if wrapper format is passed" do
+      assert_raise ArgumentError, ~r/not a theme definition/, fn ->
+        Tucan.scatter(:iris, "petal_width", "petal_length")
+        |> Tucan.set_theme(name: :my_theme, theme: [background: "#fff"])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently users must fork Tucan to add custom themes. This adds a keyword list overload to `set_theme/2` so users can pass Vega-Lite config options directly.

For example:

```elixir
Tucan.scatter(:iris, "petal_width", "petal_length")
|> Tucan.set_theme(
  background: "#0E0E0E",
  axis: [grid: false, label_color: "#FFF"],
  style: [bar: [fill: "#FDDA00"]]
)
```

## Changes

- Added a `when is_list(theme)` clause to `set_theme/2` that passes the keyword list directly to `Vl.config/2`
- Validates input: rejects empty lists and catches accidental use of the internal theme wrapper format (`:name`, `:theme`, etc.)
- Updated `@spec` to `atom() | keyword()`
- Added docs with examples for both built-in and custom theme usage
- Added tests for the new clause